### PR TITLE
Update IEDriverServer to v2.46.0

### DIFF
--- a/Selenium.WebDriver.IEDriver.nuspec
+++ b/Selenium.WebDriver.IEDriver.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Selenium.WebDriver.IEDriver</id>
-    <version>2.45.0.3</version>
+    <version>2.46.0.3</version>
     <authors>jsakamoto</authors>
     <summary>Selenium Internet Explorer Driver (Win32) (this package does not make your source repository to fat.)</summary>
     <description>
@@ -21,10 +21,12 @@
     <tags>Selenium WebDriver IEDriverServer</tags>
     <releaseNotes>
       <![CDATA[
+	  v.2.46.0.3
+	  - Update to Latest version of IEDriverServer
       v.2.45.0.3
       - Re-package to fix license URL.
       v.2.45.0.2
-      - Include IEDriverServer.exe in this package, no downloading during package instllation.
+      - Include IEDriverServer.exe in this package, no downloading during package installation.
       v.2.45
       - IE Driver 2.45 release
       v.2.44

--- a/download-driver.ps1
+++ b/download-driver.ps1
@@ -1,5 +1,5 @@
 # constants
-$version = "2.45"
+$version = "2.46"
 $driverName = "IEDriverServer.exe"
 $zipName = "IEDriverServer_Win32_$version.0.zip"
 $downloadurl = "https://selenium-release.storage.googleapis.com/$version/$zipName"


### PR DESCRIPTION
I tested this with a locally build NuGet package to confirm it pulls the new version of the Driver and that the server driver functions as expected in testing.
